### PR TITLE
Update tests and GitHub workflow

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,6 +4,9 @@
 end_of_line = lf
 insert_final_newline = true
 
+[*.{yml,yaml}]
+trim_trailing_whitespace = true
+
 [*.{lua,yml,yaml}]
 indent_size = 2
 indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# https://editorconfig.org
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{lua,yml,yaml}]
+indent_size = 2
+indent_style = space

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         nvim-version: [ stable, nightly ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Install Neovim ${{ matrix.nvim-version }}
         uses: rhysd/action-setup-vim@v1
@@ -23,6 +23,4 @@ jobs:
       
       - name: Run tests
         run: |
-          cd ${{ github.workspace }}
-          nvim --headless -u NONE \
-            +"lua dofile('test/run_all.lua')" +qa!
+          nvim --headless -u NONE +"lua dofile('test/run_all.lua')" +cq

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,13 +14,32 @@ jobs:
         nvim-version: [ stable, nightly ]
     steps:
       - uses: actions/checkout@v4
-      
+      - uses: actions/checkout@v4
+        with:
+          repository: nvim-mini/mini.test
+          path: build/mini.test
+
       - name: Install Neovim ${{ matrix.nvim-version }}
         uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
           version: ${{ matrix.nvim-version }}
-      
+
+      - name: Install Lua libraries
+        run: |
+          sudo apt update --yes
+          sudo apt install --yes luarocks
+          luarocks install --local luassert
+
+      # headless MiniTest exits non-zero when there are test failures,
+      # and the final cquit exits non-zero when MiniTest fails
       - name: Run tests
         run: |
           nvim --headless -u NONE +"lua dofile('test/run_all.lua')" +cq
+
+          eval "$(luarocks path)"
+          nvim --headless -u NONE \
+          +"set rtp+=$(pwd)/build/mini.test" \
+          +"lua require('mini.test').setup()" \
+          +"lua MiniTest.run_file('test/spec/parsers_spec.lua')" \
+          +"cquit"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,11 @@ jobs:
       matrix:
         nvim-version: [ stable, nightly ]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
+      - name: Checkout plugin
+        uses: actions/checkout@v4
+
+      - name: Checkout mini.test
+        uses: actions/checkout@v4
         with:
           repository: nvim-mini/mini.test
           path: build/mini.test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ We welcome contributions! Here's how you can help:
 ### Running Tests
 ```bash
 # Quick tests (no dependencies)
-nvim --headless -u NONE +"lua dofile('test/run_tests.lua')" +qa
+nvim --headless -u NONE +"lua dofile('test/run_tests.lua')" +cq
 
 # Plenary/Busted tests (with organized suites)
 nvim --headless --noplugin -u NONE -c "set rtp+=$(pwd)" +"lua require('test.spec.lcov_parser_spec')" +qa

--- a/lua/crazy-coverage/parser/llvm_json.lua
+++ b/lua/crazy-coverage/parser/llvm_json.lua
@@ -160,18 +160,13 @@ function M.parse(file_path, project_root)
             ::continue::
           end
           
-          -- Convert line coverage map to sorted array
+          -- Convert line coverage map to array
           for line_num, hit_count in pairs(line_coverage) do
             table.insert(file_entry.lines, {
               line = line_num,
               hits = hit_count,
             })
           end
-          
-          -- Sort by line number
-          table.sort(file_entry.lines, function(a, b)
-            return a.line < b.line
-          end)
           
           -- Log success if debug is enabled
           local config = require("crazy-coverage.config")
@@ -206,6 +201,11 @@ function M.parse(file_path, project_root)
         end
 
         if source_file_path then
+          -- Sort by line number
+          table.sort(file_entry.lines, function(a, b)
+            return a.line < b.line
+          end)
+
           coverage_data[source_file_path] = file_entry
         end
       end

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -1,6 +1,9 @@
 -- Test helpers and utilities
 local M = {}
 
+assert = require("luassert")
+vim.opt.rtp:append(vim.fn.getcwd())
+
 -- Create temporary coverage files for testing
 function M.create_temp_coverage_file(format, content)
   local tmp_dir = "/tmp/crazy-coverage-test-" .. os.time()
@@ -35,7 +38,7 @@ end
 
 -- Sample coverage data generators
 function M.sample_llvm_coverage()
-  return [[{
+  return [=[{
   "version": "2.0.1",
   "data": [{
     "files": [{
@@ -43,11 +46,11 @@ function M.sample_llvm_coverage()
       "segments": [[10, 0, 5, true, false, false], [11, 0, 0, true, false, false], [12, 0, 3, true, false, false]]
     }]
   }]
-}]]
+}]=]
 end
 
 function M.sample_cobertura_coverage()
-  return [[<?xml version="1.0" ?>
+  return [=[<?xml version="1.0" ?>
 <coverage version="5.4" timestamp="1234567890" lines-valid="3" lines-covered="2" line-rate="0.667">
   <packages>
     <package name="main" line-rate="0.667" branch-rate="1.0">
@@ -63,17 +66,17 @@ function M.sample_cobertura_coverage()
       </classes>
     </package>
   </packages>
-</coverage>]]
+</coverage>]=]
 end
 
 function M.sample_lcov_coverage()
-  return [[TN:main.c
+  return [=[TN:main.c
 SF:../main.c
 DA:10,5
 DA:11,0
 DA:12,3
 end_of_record
-]]
+]=]
 end
 
 return M

--- a/test/run_all.lua
+++ b/test/run_all.lua
@@ -1,5 +1,5 @@
 -- Headless test runner for quick manual testing
--- Run with: nvim --headless -u NONE -c "lua dofile('test/run_all.lua')" +qa
+-- Run with: nvim --headless -u NONE -c "lua dofile('test/run_all.lua')" +cq
 
 local cwd = vim.fn.getcwd()
 package.path = package.path .. ';' .. cwd .. '/lua/?.lua;' .. cwd .. '/lua/?/init.lua;' .. cwd .. '/lua/?/?.lua'
@@ -139,22 +139,29 @@ end)
 print("\n[File Parsing]")
 test("Parse LCOV fixture", function()
   local data = parser.parse(cwd .. "/test/fixtures/sample_coverage.lcov")
-  assert(data ~= nil and data.files ~= nil)
+  assert(type(data) == 'table')
+
+  local file, info = next(data)
+  assert(file and info and type(info.lines) == 'table')
 end)
 test("Parse JSON fixture", function()
   local data = parser.parse(cwd .. "/test/fixtures/sample_coverage.json")
-  assert(data ~= nil and data.files ~= nil)
+  assert(type(data) == 'table')
+
+  local file, info = next(data)
+  assert(file and info and type(info.lines) == 'table')
 end)
 test("Parse XML fixture", function()
   local data = parser.parse(cwd .. "/test/fixtures/sample_coverage.xml")
-  assert(data ~= nil and data.files ~= nil)
+  assert(type(data) == 'table')
+
+  local file, info = next(data)
+  assert(file and info and type(info.lines) == 'table')
 end)
 
 -- Summary
-print("\n" .. "=" .. string.rep("=", 58))
+print("\n" .. string.rep("=", 58))
 print(string.format("Results: %d passed, %d failed", passed, failed))
-print("=" .. string.rep("=", 58))
+print(string.rep("=", 58) .. "\n")
 
-if failed > 0 then
-  vim.fn.exit(1)
-end
+vim.cmd(failed == 0 and 'qall!' or 'cquit!')

--- a/test/spec/parsers_spec.lua
+++ b/test/spec/parsers_spec.lua
@@ -26,12 +26,12 @@ describe("LLVM JSON Parser", function()
       for file_path, _ in pairs(result) do
         assert.is_string(file_path)
         -- Path should not contain unresolved .. segments
-        assert.is_false(file_path:match("%.%."))
+        assert.is_falsy(file_path:match("%.%."))
       end
     end)
 
     it("should preserve absolute paths", function()
-      local content = [[
+      local content = [=[
 {
   "version": "2.0.1",
   "data": [{
@@ -41,7 +41,7 @@ describe("LLVM JSON Parser", function()
     }]
   }]
 }
-]]
+]=]
       temp_file, temp_dir = helpers.create_temp_coverage_file("llvm", content)
       
       local result = llvm_parser.parse(temp_file, temp_dir)
@@ -58,7 +58,7 @@ describe("LLVM JSON Parser", function()
     end)
 
     it("should handle multiple relative path segments", function()
-      local content = [[
+      local content = [=[
 {
   "version": "2.0.1",
   "data": [{
@@ -68,7 +68,7 @@ describe("LLVM JSON Parser", function()
     }]
   }]
 }
-]]
+]=]
       temp_file, temp_dir = helpers.create_temp_coverage_file("llvm", content)
       
       local result = llvm_parser.parse(temp_file, temp_dir)
@@ -92,7 +92,7 @@ describe("LLVM JSON Parser", function()
       local result = llvm_parser.parse(temp_file, temp_dir)
       
       assert.is_not_nil(result)
-      local file_data = next(result)
+      local _, file_data = next(result)
       assert.is_not_nil(file_data)
       assert.is_table(file_data.lines)
       
@@ -113,7 +113,7 @@ describe("LLVM JSON Parser", function()
       temp_file, temp_dir = helpers.create_temp_coverage_file("llvm", helpers.sample_llvm_coverage())
       
       local result = llvm_parser.parse(temp_file, temp_dir)
-      local file_data = next(result)
+      local _, file_data = next(result)
       
       -- Line 11 in sample has count=0
       local line_11_data
@@ -133,7 +133,7 @@ describe("LLVM JSON Parser", function()
       temp_file, temp_dir = helpers.create_temp_coverage_file("llvm", helpers.sample_llvm_coverage())
       
       local result = llvm_parser.parse(temp_file, temp_dir)
-      local file_data = next(result)
+      local _, file_data = next(result)
       
       -- Lines 10 and 12 in sample have count > 0
       local covered_count = 0
@@ -149,7 +149,7 @@ describe("LLVM JSON Parser", function()
 
   describe("Format A (lines array) parsing", function()
     it("should parse lines array format (standard llvm-cov output)", function()
-      local content = [[{
+      local content = [=[{
   "version": "2.0.1",
   "data": [{
     "files": [{
@@ -161,31 +161,28 @@ describe("LLVM JSON Parser", function()
       ]
     }]
   }]
-}]]
+}]=]
       temp_file, temp_dir = helpers.create_temp_coverage_file("llvm", content)
       
       local result = llvm_parser.parse(temp_file, temp_dir)
       
       assert.is_not_nil(result)
-      local file_data = next(result)
+      local _, file_data = next(result)
       assert.is_not_nil(file_data)
       assert.equals(3, #file_data.lines)
       
       -- Check line 5 is covered
-      assert.equals(10, file_data.lines[1].hit_count)
-      assert.is_true(file_data.lines[1].covered)
+      assert.equals(10, file_data.lines[1].hits)
       
       -- Check line 6 is uncovered
-      assert.equals(0, file_data.lines[2].hit_count)
-      assert.is_false(file_data.lines[2].covered)
+      assert.equals(0, file_data.lines[2].hits)
       
       -- Check line 7 is covered
-      assert.equals(5, file_data.lines[3].hit_count)
-      assert.is_true(file_data.lines[3].covered)
+      assert.equals(5, file_data.lines[3].hits)
     end)
 
     it("should parse regions as branch coverage", function()
-      local content = [[{
+      local content = [=[{
   "version": "2.0.1",
   "data": [{
     "files": [{
@@ -202,29 +199,26 @@ describe("LLVM JSON Parser", function()
       ]
     }]
   }]
-}]]
+}]=]
       temp_file, temp_dir = helpers.create_temp_coverage_file("llvm", content)
       
       local result = llvm_parser.parse(temp_file, temp_dir)
       
       assert.is_not_nil(result)
-      local file_data = next(result)
+      local _, file_data = next(result)
       assert.equals(1, #file_data.lines)
       assert.equals(2, #file_data.branches)
       
       -- Check line coverage
-      assert.equals(5, file_data.lines[1].hit_count)
-      assert.is_true(file_data.lines[1].covered)
+      assert.equals(5, file_data.lines[1].hits)
       
       -- Check branch coverage from regions
-      assert.equals(5, file_data.branches[1].hit_count)
-      assert.is_true(file_data.branches[1].covered)
-      assert.equals(2, file_data.branches[2].hit_count)
-      assert.is_true(file_data.branches[2].covered)
+      assert.equals(5, file_data.branches[1].hits)
+      assert.equals(2, file_data.branches[2].hits)
     end)
 
     it("should handle uncovered regions correctly", function()
-      local content = [[{
+      local content = [=[{
   "version": "2.0.1",
   "data": [{
     "files": [{
@@ -240,21 +234,19 @@ describe("LLVM JSON Parser", function()
       ]
     }]
   }]
-}]]
+}]=]
       temp_file, temp_dir = helpers.create_temp_coverage_file("llvm", content)
       
       local result = llvm_parser.parse(temp_file, temp_dir)
       
       assert.is_not_nil(result)
-      local file_data = next(result)
+      local _, file_data = next(result)
       assert.equals(1, #file_data.lines)
-      assert.is_false(file_data.lines[1].covered)
       assert.equals(1, #file_data.branches)
-      assert.is_false(file_data.branches[1].covered)
     end)
 
     it("should preserve line numbers in order", function()
-      local content = [[{
+      local content = [=[{
   "version": "2.0.1",
   "data": [{
     "files": [{
@@ -266,17 +258,18 @@ describe("LLVM JSON Parser", function()
       ]
     }]
   }]
-}]]
+}]=]
       temp_file, temp_dir = helpers.create_temp_coverage_file("llvm", content)
       
       local result = llvm_parser.parse(temp_file, temp_dir)
       
       assert.is_not_nil(result)
-      local file_data = next(result)
+      local _, file_data = next(result)
+
       -- Should be sorted by line number
-      assert.equals(50, file_data.lines[1].line_num)
-      assert.equals(75, file_data.lines[2].line_num)
-      assert.equals(100, file_data.lines[3].line_num)
+      assert.equals(50, file_data.lines[1].line)
+      assert.equals(75, file_data.lines[2].line)
+      assert.equals(100, file_data.lines[3].line)
     end)
   end)
 end)
@@ -304,12 +297,12 @@ describe("Cobertura Parser", function()
       for file_path, _ in pairs(result) do
         assert.is_string(file_path)
         -- Should not contain unresolved .. segments
-        assert.is_false(file_path:match("%.%."))
+        assert.is_falsy(file_path:match("%.%."))
       end
     end)
 
     it("should use absolute path when available", function()
-      local content = [[
+      local content = [=[
 <?xml version="1.0" ?>
 <coverage version="5.4" timestamp="1234567890">
   <packages>
@@ -324,7 +317,7 @@ describe("Cobertura Parser", function()
     </package>
   </packages>
 </coverage>
-]]
+]=]
       temp_file, temp_dir = helpers.create_temp_coverage_file("xml", content)
       
       local result = cobertura_parser.parse(temp_file, temp_dir)
@@ -346,7 +339,7 @@ describe("Cobertura Parser", function()
       temp_file, temp_dir = helpers.create_temp_coverage_file("xml", helpers.sample_cobertura_coverage())
       
       local result = cobertura_parser.parse(temp_file, temp_dir)
-      local file_data = next(result)
+      local _, file_data = next(result)
       
       assert.is_not_nil(file_data)
       assert.is_table(file_data.lines)
@@ -365,7 +358,7 @@ describe("Cobertura Parser", function()
       temp_file, temp_dir = helpers.create_temp_coverage_file("xml", helpers.sample_cobertura_coverage())
       
       local result = cobertura_parser.parse(temp_file, temp_dir)
-      local file_data = next(result)
+      local _, file_data = next(result)
       
       -- Sample has line 11 with hits=0
       local has_uncovered = false
@@ -382,7 +375,7 @@ describe("Cobertura Parser", function()
       temp_file, temp_dir = helpers.create_temp_coverage_file("xml", helpers.sample_cobertura_coverage())
       
       local result = cobertura_parser.parse(temp_file, temp_dir)
-      local file_data = next(result)
+      local _, file_data = next(result)
       
       -- Sample has lines 10 and 12 with hits > 0
       local covered_count = 0
@@ -397,7 +390,7 @@ describe("Cobertura Parser", function()
 
   describe("branch coverage", function()
     it("should parse branch data when available", function()
-      local content = [[
+      local content = [=[
 <?xml version="1.0" ?>
 <coverage version="5.4" timestamp="1234567890">
   <packages>
@@ -416,14 +409,14 @@ describe("Cobertura Parser", function()
     </package>
   </packages>
 </coverage>
-]]
+]=]
       temp_file, temp_dir = helpers.create_temp_coverage_file("xml", content)
       
       local result = cobertura_parser.parse(temp_file, temp_dir)
       
       assert.is_not_nil(result)
       -- Parser should handle branch data without errors
-      local file_data = next(result)
+      local _, file_data = next(result)
       assert.is_not_nil(file_data)
     end)
   end)
@@ -452,18 +445,18 @@ describe("LCOV Parser", function()
       for file_path, _ in pairs(result) do
         assert.is_string(file_path)
         -- Should not contain unresolved .. segments
-        assert.is_false(file_path:match("%.%."))
+        assert.is_falsy(file_path:match("%.%."))
       end
     end)
 
     it("should use absolute paths when present in SF:", function()
-      local content = [[
+      local content = [=[
 TN:test
 SF:/absolute/path/main.c
 DA:10,5
 DA:11,0
 end_of_record
-]]
+]=]
       temp_file, temp_dir = helpers.create_temp_coverage_file("lcov", content)
       
       local result = lcov_parser.parse(temp_file, temp_dir)
@@ -480,7 +473,7 @@ end_of_record
     end)
 
     it("should handle multiple source files", function()
-      local content = [[
+      local content = [=[
 TN:test
 SF:../file1.c
 DA:10,5
@@ -488,7 +481,7 @@ end_of_record
 SF:../file2.c
 DA:20,3
 end_of_record
-]]
+]=]
       temp_file, temp_dir = helpers.create_temp_coverage_file("lcov", content)
       
       local result = lcov_parser.parse(temp_file, temp_dir)
@@ -508,7 +501,7 @@ end_of_record
       temp_file, temp_dir = helpers.create_temp_coverage_file("lcov", helpers.sample_lcov_coverage())
       
       local result = lcov_parser.parse(temp_file, temp_dir)
-      local file_data = next(result)
+      local _, file_data = next(result)
       
       assert.is_not_nil(file_data)
       assert.is_table(file_data.lines)
@@ -525,7 +518,7 @@ end_of_record
       temp_file, temp_dir = helpers.create_temp_coverage_file("lcov", helpers.sample_lcov_coverage())
       
       local result = lcov_parser.parse(temp_file, temp_dir)
-      local file_data = next(result)
+      local _, file_data = next(result)
       
       -- Sample has line 11 with 0 hits
       local has_uncovered = false
@@ -542,7 +535,7 @@ end_of_record
       temp_file, temp_dir = helpers.create_temp_coverage_file("lcov", helpers.sample_lcov_coverage())
       
       local result = lcov_parser.parse(temp_file, temp_dir)
-      local file_data = next(result)
+      local _, file_data = next(result)
       
       -- Sample has lines with hits > 0
       local covered_count = 0
@@ -557,20 +550,20 @@ end_of_record
 
   describe("branch data parsing", function()
     it("should parse BRDA: (branch data) entries", function()
-      local content = [[
+      local content = [=[
 TN:test
 SF:../main.c
 DA:10,5
 BRDA:10,0,0,3
 BRDA:10,0,1,2
 end_of_record
-]]
+]=]
       temp_file, temp_dir = helpers.create_temp_coverage_file("lcov", content)
       
       local result = lcov_parser.parse(temp_file, temp_dir)
       
       assert.is_not_nil(result)
-      local file_data = next(result)
+      local _, file_data = next(result)
       assert.is_not_nil(file_data)
       assert.equals(2, #file_data.branches)
       assert.equals(0, file_data.branches[1].id)
@@ -707,7 +700,7 @@ describe("Edge Cases", function()
       
       assert.is_not_nil(result)
       -- Should reduce to single slashes
-      assert.is_false(result:match("//"))
+      assert.is_falsy(result:match("//"))
     end)
   end)
 
@@ -734,11 +727,11 @@ describe("Edge Cases", function()
     end)
 
     it("should handle coverage with no line data", function()
-      local content = [[
+      local content = [=[
 TN:test
 SF:../main.c
 end_of_record
-]]
+]=]
       temp_file, temp_dir = helpers.create_temp_coverage_file("lcov", content)
       
       local parser = require("crazy-coverage.parser.init")
@@ -746,26 +739,26 @@ end_of_record
       
       assert.is_not_nil(result)
       -- File should be in result but with empty or no lines
-      local file_data = next(result)
+      local _, file_data = next(result)
       if file_data and file_data.lines then
         assert.equals(0, #file_data.lines)
       end
     end)
 
     it("should handle very large hit counts", function()
-      local content = [[
+      local content = [=[
 TN:test
 SF:../main.c
 DA:10,999999999
 end_of_record
-]]
+]=]
       temp_file, temp_dir = helpers.create_temp_coverage_file("lcov", content)
       
       local parser = require("crazy-coverage.parser.init")
       local result = parser.parse(temp_file)
       
       assert.is_not_nil(result)
-      local file_data = next(result)
+      local _, file_data = next(result)
       assert.is_not_nil(file_data)
       
       -- Should handle large numbers correctly
@@ -959,7 +952,7 @@ describe("Coverage File Caching", function()
     it("normalizes cached paths", function()
       local path = "/path/to/project/./build/../coverage.lcov"
       local normalized = utils.normalize_path(path)
-      assert.equals("/path/to/project/build/coverage.lcov", normalized)
+      assert.equals("/path/to/project/coverage.lcov", normalized)
     end)
 
     it("normalizes project_root", function()


### PR DESCRIPTION
This fixes the few issues I encountered while trying to run the test suite locally. For the most part, these are small adjustments to the parser spec to match the changes in fec54b52e50e4ba5e4567086d092113c06cf54aa. Occurrences of `qall` are now `cquit`, which I learned exits non-zero.

This also uses MiniTest to run the parser specs during a pull request.

## Summary by Sourcery

Align parser tests, helpers, and documentation with the current coverage data structures and add automated MiniTest execution to the CI workflow.

Enhancements:
- Refine LLVM JSON parser line handling by moving line sorting to occur only when a source file path is present, avoiding unnecessary work for skipped entries.

CI:
- Enhance the test workflow to install MiniTest, check out its repository, and run parser specs under MiniTest alongside the existing headless test runner, updating actions to checkout v4 and ensuring failing tests cause a non-zero exit.

Documentation:
- Update CONTRIBUTING instructions for running the test suite to use the new headless command that exits non-zero on failure.

Tests:
- Update parser and edge-case specs to use the new coverage fields and assertions, adjust temporary fixture content, and refine expectations around path normalization and line ordering.
- Improve the manual headless test runner to validate parsed coverage structures more robustly and to exit non-zero on failure via Neovim commands.
- Introduce shared test helpers that configure luassert, adjust runtime path, and provide sample coverage fixtures using long string syntax.

Chores:
- Add a basic .editorconfig file to standardize editor behavior across the project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added EditorConfig to standardize line endings, final newlines, and indentation.
  * Upgraded CI workflow and test setup for more reliable dependency handling and failure reporting.

* **Tests**
  * Adjusted test runner exit behavior and assertion style; integrated additional assertion tooling and runtime-path setup.
  * Updated test fixtures formatting and expectations to match parser outputs.

* **Refactor**
  * Normalized parser output shape and deferred internal sorting to a common step for consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->