### PR TITLE
Add coverage status display in sign column

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Neovim plugin for displaying code coverage overlays directly in your editor wi
 
 - **Multi-Format Support**: LCOV, LLVM JSON, Cobertura XML, Go Coverprofile, GCOV, LLVM Profdata
 - **Smart Toggle**: Single command auto-loads coverage and watches for changes
-- **Flexible Display**: Show hit counts via virtual text or sign column
+- **Flexible Display**: Show hit counts via virtual text and move coverage status into the sign column
 - **Branch/Region Overlays**: Inspect branch and LLVM region hit details at cursor
 - **Tree Integration**: Coverage in NvimTree and neo-tree (optional)
 - **Configurable**: Customize colors, display behavior, and summary popup
@@ -131,6 +131,7 @@ require("crazy-coverage").setup({
     show_by_default = true,        -- Show hit counts when coverage is enabled
     display = "eol",              -- "eol", "inline", "overlay", "right_align", "sign"
   },
+  show_coverage_in_sign_column = false,
   auto_adapt_colors = true,       -- Auto-adapt colors to your theme
 })
 ```
@@ -175,6 +176,7 @@ See [Configuration Reference](doc/configuration.md) for all 15+ options.
 |---------|-------------|
 | `:CoverageToggle` | Toggle coverage overlay (auto-loads, watches file) |
 | `:CoverageToggleHitCount` | Toggle hit count display |
+| `:CoverageToggleSignColumn` | Toggle coverage status in the sign column |
 | `:CoverageToggleBranchOverlay` | Toggle branch overlay at cursor |
 | `:CoverageToggleRegionOverlay` | Toggle LLVM region overlay at cursor |
 | `:CoverageToggleNvimTree` | Toggle coverage display in NvimTree |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Neovim plugin for displaying code coverage overlays directly in your editor wi
 
 - **Multi-Format Support**: LCOV, LLVM JSON, Cobertura XML, Go Coverprofile, GCOV, LLVM Profdata
 - **Smart Toggle**: Single command auto-loads coverage and watches for changes
-- **Flexible Display**: Show hit counts via virtual text and move coverage status into the sign column
+- **Flexible Display**: Show hit counts via virtual text, with optional coverage status in the sign column
 - **Branch/Region Overlays**: Inspect branch and LLVM region hit details at cursor
 - **Tree Integration**: Coverage in NvimTree and neo-tree (optional)
 - **Configurable**: Customize colors, display behavior, and summary popup

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -75,6 +75,17 @@ Display coverage percentage for each line. When enabled, shows the percentage of
 show_percentage = false
 ```
 
+### `show_coverage_in_sign_column`
+
+**Type:** `boolean`
+**Default:** `false`
+
+Show coverage status in the sign column instead of using in-buffer line highlights for coverage lines. Hit-count display is still controlled separately by `hit_count.display`.
+
+```lua
+show_coverage_in_sign_column = true
+```
+
 ### `show_branch_summary`
 
 **Type:** `boolean`
@@ -160,6 +171,7 @@ nvim_tree = {
 ```
 
 **Fill symbols** indicate coverage level:
+
 - `▁` (0-20%)
 - `▂` (20-40%)
 - `▄` (40-60%)
@@ -205,6 +217,7 @@ neo_tree = {
 ```
 
 **Fill symbols** indicate coverage level:
+
 - `▁` (0-20%)
 - `▂` (20-40%)
 - `▄` (40-60%)
@@ -230,6 +243,7 @@ require("crazy-coverage").setup({
   },
 })
 ```
+
 ```
 
 ## Highlight Groups
@@ -268,6 +282,7 @@ require("crazy-coverage").setup({
 **Default:** `{ covered = nil, uncovered = nil, partial = nil }`
 
 Manual color overrides for coverage highlighting. Each color can be:
+
 - A hex string: `"#00AA00"` (sets background only)
 - A table: `{ bg = "#00AA00", fg = "#FFFFFF" }` (sets background and foreground)
 - `nil` (uses auto-adapted colors if `auto_adapt_colors = true`)
@@ -401,6 +416,7 @@ require("crazy-coverage").setup({
 When auto-adaptation is enabled, the plugin detects your theme and uses:
 
 **Dark themes:**
+
 ```lua
 covered   = { bg = "#003300", fg = "#00FF00" }  -- Dark green bg, bright green fg
 uncovered = { bg = "#330000", fg = "#FF4444" }  -- Dark red bg, bright red fg
@@ -408,6 +424,7 @@ partial   = { bg = "#332200", fg = "#FFAA00" }  -- Dark yellow bg, bright orange
 ```
 
 **Light themes:**
+
 ```lua
 covered   = { bg = "#CCFFCC", fg = "#006600" }  -- Light green bg, dark green fg
 uncovered = { bg = "#FFCCCC", fg = "#CC0000" }  -- Light red bg, dark red fg
@@ -422,6 +439,7 @@ These colors are automatically re-applied when the colorscheme changes.
 
 **Type:** `table`
 **Default:**
+
 ```lua
 {
   "build/coverage",  -- Standard CMake coverage output
@@ -436,12 +454,14 @@ Directories to search for coverage files, relative to the project root. The plug
 **Intelligent File Detection**: The plugin doesn't just search for filenames - it verifies files by reading their content to confirm they're valid coverage files. This means coverage files can have any name and any extension, as long as the file contains valid coverage data.
 
 **Search order example:**
+
 1. Check `project_root/build/coverage/` - for any coverage file
 2. Check `project_root/coverage/` - for any coverage file
 3. Check `project_root/build/` - for any coverage file
 4. Check `project_root/` - for any coverage file
 
 **Supported Coverage Formats** (auto-detected by content):
+
 - **LCOV**: Files containing `TN:`, `FN:`, `DA:`, or `end_of_record` markers
 - **LLVM JSON**: Files containing `"version"` and `"data"` fields
 - **Cobertura XML**: Files containing `<coverage>`, `<package>`, or `<class>` tags
@@ -451,6 +471,7 @@ Directories to search for coverage files, relative to the project root. The plug
 Filename doesn't matter - the plugin verifies coverage by actual content!
 
 **Examples of auto-detected files:**
+
 ```
 project_root/build/my_coverage_report         ← No extension
 project_root/coverage_2025_01_09.json         ← Custom name
@@ -475,6 +496,7 @@ coverage_dirs = {
 
 **Type:** `table`
 **Default:**
+
 ```lua
 {
   c = { "*.lcov", "*.info", "coverage.json", "coverage.xml", "*.profdata" },
@@ -532,6 +554,7 @@ cache_enabled = true
 **Default:** `vim.fn.stdpath("cache") .. "/crazy-coverage.nvim"`
 
 Directory where cached coverage data is stored. On most systems, this defaults to:
+
 - Linux: `~/.cache/nvim/crazy-coverage.nvim`
 - macOS: `~/Library/Caches/nvim/crazy-coverage.nvim`
 - Windows: `~/AppData/Local/nvim-data/crazy-coverage.nvim`
@@ -548,6 +571,7 @@ cache_dir = vim.fn.stdpath("cache") .. "/crazy-coverage.nvim"
 **Deprecated:** This option is deprecated in favor of using `:CoverageToggle` which provides smarter auto-loading with file watching.
 
 When `true`, attempts to auto-load coverage when opening a file. However, it's recommended to use `:CoverageToggle` instead, which provides:
+
 - Explicit control over when coverage is loaded
 - File watching for automatic reloading
 - Cleaner resource management

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -244,8 +244,6 @@ require("crazy-coverage").setup({
 })
 ```
 
-```
-
 ## Highlight Groups
 
 ### `auto_adapt_colors`

--- a/doc/sign-display-feature.md
+++ b/doc/sign-display-feature.md
@@ -65,7 +65,7 @@ require("crazy-coverage").setup({
 ## Commands
 
 - `:CoverageToggleSignColumn` - Toggle coverage status in the sign column
-- `:CoverageToggleHitCount` - Toggle end-of-line virtual text (existing feature)
+- `:CoverageToggleHitCount` - Toggle hit-count display on/off for `eol`, `inline`, `overlay`, `right_align`, or `sign`
 
 ## Usage Examples
 

--- a/doc/sign-display-feature.md
+++ b/doc/sign-display-feature.md
@@ -1,80 +1,113 @@
 # Sign Column and Line Number Display Feature
 
-This feature adds the ability to display coverage hit counts near line numbers in two ways:
+This document covers the legacy hit-count sign display and the newer coverage-status sign-column mode.
 
 ## Display Modes
 
-### 1. Sign Column Display (`show_hit_count_in_sign`)
-Shows hit counts in the sign column (left gutter) next to line numbers.
+### 1. Coverage Status in Sign Column (`show_coverage_in_sign_column`)
+
+Shows coverage status in the sign column and keeps hit-count display controlled separately by `hit_count.display`.
+
 - **Default**: `false` (disabled)
+- **Behavior**: Replaces in-buffer coverage line highlighting with sign-column coverage markers
+- **Hit counts**: Still shown using the existing hit-count display settings
+
+```lua
+require("crazy-coverage").setup({
+  show_coverage_in_sign_column = true,
+  hit_count = {
+    display = "eol",
+  },
+})
+```
+
+### 2. Legacy Hit Count Sign Display (`hit_count.display = "sign"`)
+
+Shows hit counts in the sign column (left gutter) next to line numbers.
+
+- **Default**: `eol` for the built-in configuration
 - **Note**: Sign column is shared with git-signs, diagnostics, and debugger
 - **Tip**: Use `set signcolumn=auto:2` to show multiple signs simultaneously
 
-### 2. Line Number Highlighting (`highlight_line_numbers`)
-Colorizes line numbers based on coverage status (covered/uncovered/partial).
+### 3. Coverage Line Highlighting (`enable_line_hl`)
+
+Highlights coverage status in the buffer (covered/uncovered/partial) using line background colors.
+
 - **Default**: `true` (enabled)
-- **Requires**: `:set number` to be enabled in Neovim
+
+```lua
+enable_line_hl = true
+```
 
 ## Configuration
 
 ```lua
 require("crazy-coverage").setup({
-  -- Show hit count in sign column (e.g., "3" or "9+")
-  show_hit_count_in_sign = false,
+  -- Show coverage status in the sign column instead of in-buffer line highlighting
+  show_coverage_in_sign_column = false,
 
-  -- Highlight line numbers based on coverage
-  highlight_line_numbers = true,
+  -- Show hit counts in the sign column (e.g., "3" or "9+")
+  hit_count = {
+    display = "eol",
+    sign_text_format = function(hit_count)
+      if hit_count >= 10 then
+        return "9+"
+      end
+      return tostring(hit_count)
+    end,
+  },
 
-  -- Custom format for sign text (max 2 chars recommended)
-  sign_text_format = function(hit_count)
-    if hit_count >= 10 then
-      return "9+"
-    end
-    return tostring(hit_count)
-  end,
+  -- Keep in-buffer coverage highlights if you do not want sign-only coverage
+  enable_line_hl = true,
 })
 ```
 
 ## Commands
 
-- `:CoverageToggleSign` - Toggle hit count display in sign column
-- `:CoverageToggleLineNumbers` - Toggle line number highlighting
+- `:CoverageToggleSignColumn` - Toggle coverage status in the sign column
 - `:CoverageToggleHitCount` - Toggle end-of-line virtual text (existing feature)
 
 ## Usage Examples
 
 ### Example 1: Sign Column Only
+
 ```lua
 require("crazy-coverage").setup({
-  show_hit_count = false,           -- Disable end-of-line display
-  show_hit_count_in_sign = true,    -- Enable sign column
-  highlight_line_numbers = true,     -- Enable line number colors
-  enable_line_hl = false,            -- Disable line highlighting
+  show_coverage_in_sign_column = true, -- Coverage markers in the gutter
+  hit_count = {
+    display = "eol",                -- Keep hit counts in the buffer
+  },
+  enable_line_hl = false,            -- Disable coverage line highlighting
 })
 ```
 
 ### Example 2: All Display Modes
+
 ```lua
 require("crazy-coverage").setup({
-  show_hit_count = true,             -- End-of-line virtual text
-  show_hit_count_in_sign = true,     -- Sign column
-  highlight_line_numbers = true,     -- Line number colors
-  enable_line_hl = true,             -- Full line highlighting
+  show_coverage_in_sign_column = true, -- Coverage markers in the gutter
+  hit_count = {
+    display = "sign",               -- Hit counts in the sign column too
+  },
+  enable_line_hl = false,             -- Coverage line highlighting disabled in sign mode
 })
 ```
 
 ### Example 3: Custom Sign Format
+
 ```lua
 require("crazy-coverage").setup({
-  show_hit_count_in_sign = true,
-  sign_text_format = function(hit_count)
-    if hit_count >= 100 then
-      return "∞"  -- Infinity symbol for very high counts
-    elseif hit_count >= 10 then
-      return "+"
-    end
-    return tostring(hit_count)
-  end,
+  hit_count = {
+    display = "sign",
+    sign_text_format = function(hit_count)
+      if hit_count >= 100 then
+        return "∞"  -- Infinity symbol for very high counts
+      elseif hit_count >= 10 then
+        return "+"
+      end
+      return tostring(hit_count)
+    end,
+  },
 })
 ```
 
@@ -122,13 +155,17 @@ nvim -u test/test_sign_display.lua
 ## Workarounds
 
 ### For Sign Column Conflicts
+
 Enable multiple sign columns:
+
 ```vim
 set signcolumn=auto:2
 ```
 
 ### For High Hit Counts
+
 Use the `sign_text_format` function to abbreviate large numbers:
+
 ```lua
 sign_text_format = function(hit_count)
   if hit_count >= 1000 then return "K" end

--- a/lua/crazy-coverage/config.lua
+++ b/lua/crazy-coverage/config.lua
@@ -552,6 +552,10 @@ function M.set_config(user_config)
     end
   end
 
+  if user_config.show_coverage_in_sign_column == nil then
+    M.show_coverage_in_sign_column = false
+  end
+
   -- Whitelist of valid config keys
   local valid_keys = {
     covered_hl = true,

--- a/lua/crazy-coverage/config.lua
+++ b/lua/crazy-coverage/config.lua
@@ -6,6 +6,7 @@ local M = {
   uncovered_hl = "CoverageUncovered",
   partial_hl = "CoveragePartial",
 
+
   -- Auto-adapt colors based on current theme (background and foreground)
   -- When enabled, automatically adjusts coverage colors to match your colorscheme
   auto_adapt_colors = true,
@@ -39,6 +40,9 @@ local M = {
 
   -- Show percentage for lines
   show_percentage = false,
+
+  -- Show coverage status in the sign column instead of in-buffer line highlighting
+  show_coverage_in_sign_column = false,
 
   -- Show branch summary in branch overlay header (taken/total and percentage)
   show_branch_summary = true,
@@ -470,6 +474,39 @@ function M.setup_highlights()
     default = false,
   })
 
+  -- Sign glyph highlight groups (foreground-only, no background).
+  -- These are internal-only names generated here and not intended for
+  -- user configuration. They are based on the primary line highlight
+  -- group names with a "Sign" suffix.
+  local covered_sign = (M.covered_hl or "CoverageCovered") .. "Sign"
+  local uncovered_sign = (M.uncovered_hl or "CoverageUncovered") .. "Sign"
+  local partial_sign = (M.partial_hl or "CoveragePartial") .. "Sign"
+
+  M.covered_sign_hl = covered_sign
+  M.uncovered_sign_hl = uncovered_sign
+  M.partial_sign_hl = partial_sign
+
+  vim.api.nvim_set_hl(0, covered_sign, {
+    fg = covered_color.bg,
+    bg = "NONE",
+    bold = true,
+    default = false,
+  })
+
+  vim.api.nvim_set_hl(0, uncovered_sign, {
+    fg = uncovered_color.bg,
+    bg = "NONE",
+    bold = true,
+    default = false,
+  })
+
+  vim.api.nvim_set_hl(0, partial_sign, {
+    fg = partial_color.bg,
+    bg = "NONE",
+    bold = true,
+    default = false,
+  })
+
   vim.api.nvim_set_hl(0, (M.region_overlay and M.region_overlay.highlight_hl) or "CoverageRegionActive", {
     bg = partial_color.bg,
     fg = partial_color.fg,
@@ -526,6 +563,7 @@ function M.set_config(user_config)
     default_show_hit_count = true,
     show_hit_count = true,
     show_percentage = true,
+    show_coverage_in_sign_column = true,
     show_branch_summary = true,
     enable_line_hl = true,
     center_on_navigate = true,

--- a/lua/crazy-coverage/init.lua
+++ b/lua/crazy-coverage/init.lua
@@ -1131,7 +1131,7 @@ end
 
 --- Toggle coverage display in the sign column
 function M.toggle_sign_column()
-  local current_config = config.get_config()
+  local current_config = vim.deepcopy(config.get_config())
   current_config.show_coverage_in_sign_column = not current_config.show_coverage_in_sign_column
   config.set_config(current_config)
 
@@ -1258,10 +1258,6 @@ function M.create_commands()
 
   vim.api.nvim_create_user_command("CoveragePrevPartial", function()
     M.prev_partial()
-  end, {})
-
-  vim.api.nvim_create_user_command("CoverageToggleHitCount", function()
-    M.toggle_hitcount()
   end, {})
 
   -- Toggle branch overlay floating window

--- a/lua/crazy-coverage/init.lua
+++ b/lua/crazy-coverage/init.lua
@@ -1129,6 +1129,21 @@ function M.toggle_hitcount()
   vim.notify("Hit count display: " .. status, vim.log.levels.INFO)
 end
 
+--- Toggle coverage display in the sign column
+function M.toggle_sign_column()
+  local current_config = config.get_config()
+  current_config.show_coverage_in_sign_column = not current_config.show_coverage_in_sign_column
+  config.set_config(current_config)
+
+  -- Re-render if coverage is enabled
+  if state.is_enabled and state.coverage_data then
+    renderer.render(state.coverage_data, state.project_root)
+  end
+
+  local status = current_config.show_coverage_in_sign_column and "enabled" or "disabled"
+  vim.notify("Coverage sign column: " .. status, vim.log.levels.INFO)
+end
+
 --- Toggle coverage display in NvimTree
 function M.toggle_nvim_tree()
   state.nvim_tree_enabled = not state.nvim_tree_enabled
@@ -1173,6 +1188,10 @@ function M.create_commands()
 
   vim.api.nvim_create_user_command("CoverageToggleHitCount", function()
     M.toggle_hitcount()
+  end, {})
+
+  vim.api.nvim_create_user_command("CoverageToggleSignColumn", function()
+    M.toggle_sign_column()
   end, {})
 
   vim.api.nvim_create_user_command("CoverageToggleNvimTree", function()

--- a/lua/crazy-coverage/renderer.lua
+++ b/lua/crazy-coverage/renderer.lua
@@ -174,12 +174,12 @@ local function get_hitcount_sign(buf, line_num, hit_count, hl_group, show_sign_c
       priority = 201,
       strict = false,
       sign_text = sign_text,
-      sign_hl_group = hl_group,
+      sign_hl_group = get_sign_hl_for_group(hl_group),
     })
     return nil
   end
 
-  return sign_text, hl_group
+  return sign_text, get_sign_hl_for_group(hl_group)
 end
 
 local function clear_region_highlight(buf)

--- a/lua/crazy-coverage/renderer.lua
+++ b/lua/crazy-coverage/renderer.lua
@@ -113,6 +113,74 @@ M._format_sign_text = format_sign_text
 
 M.namespace = vim.api.nvim_create_namespace("coverage_plugin")
 M.region_overlay_namespace = vim.api.nvim_create_namespace("coverage_region_overlay")
+M.hit_count_namespace = vim.api.nvim_create_namespace("coverage_hitcount_signs")
+
+-- Helper: map line highlight group to sign-specific highlight group
+local function get_sign_hl_for_group(hl_group)
+  local covered_sign = config.covered_sign_hl or (config.covered_hl .. "Sign")
+  local uncovered_sign = config.uncovered_sign_hl or (config.uncovered_hl .. "Sign")
+  local partial_sign = config.partial_sign_hl or (config.partial_hl .. "Sign")
+  if hl_group == config.covered_hl then
+    return covered_sign
+  elseif hl_group == config.uncovered_hl then
+    return uncovered_sign
+  else
+    return partial_sign
+  end
+end
+
+-- Helper: build virt_text chunks and determine virt_text_pos
+local function build_virt_text(hit_count, hit_count_display, show_sign_column, hl_group)
+  local virt = {}
+  if hit_count_display ~= "sign" and hit_count_display ~= "" and hit_count then
+    local hit_text = tostring(hit_count)
+    if not show_sign_column then
+      hit_text = " " .. tostring(hit_count)
+    end
+    local vt_hl = show_sign_column and "Normal" or hl_group
+    table.insert(virt, { hit_text, vt_hl })
+  end
+
+  if config.show_percentage and hit_count and hit_count > 0 then
+    table.insert(virt, { " (hit)", hl_group })
+  end
+
+  local pos = nil
+  if hit_count_display == "eol" or hit_count_display == "inline" or hit_count_display == "overlay" or hit_count_display == "right_align" then
+    pos = hit_count_display
+  end
+
+  return virt, pos
+end
+
+-- Helper: place hit-count sign (returns sign_text and sign_hl for use when adding to extmark)
+local function get_hitcount_sign(buf, line_num, hit_count, hl_group, show_sign_column)
+  local hit_cfg = config.hit_count or {}
+  local sign_text
+  if type(hit_cfg.sign_text_format) == "function" then
+    sign_text = hit_cfg.sign_text_format(hit_count)
+  elseif type(hit_cfg.sign_text_format) == "string" then
+    sign_text = string.format(hit_cfg.sign_text_format, hit_count)
+  else
+    sign_text = tostring(hit_count)
+  end
+  sign_text = format_sign_text(sign_text)
+  if not sign_text or sign_text == "" then
+    return nil
+  end
+
+  if show_sign_column then
+    pcall(vim.api.nvim_buf_set_extmark, buf, M.hit_count_namespace, line_num - 1, 0, {
+      priority = 201,
+      strict = false,
+      sign_text = sign_text,
+      sign_hl_group = hl_group,
+    })
+    return nil
+  end
+
+  return sign_text, hl_group
+end
 
 local function clear_region_highlight(buf)
   if buf and vim.api.nvim_buf_is_valid(buf) then
@@ -147,6 +215,7 @@ function M.clear_buffer(buf)
     return
   end
   vim.api.nvim_buf_clear_namespace(buf, M.namespace, 0, -1)
+  vim.api.nvim_buf_clear_namespace(buf, M.hit_count_namespace, 0, -1)
 end
 
 --- Clear all coverage marks from all buffers
@@ -227,6 +296,7 @@ function M.render_file(buf, file_entry)
 
   -- Track partial coverage statistics
   local partial_lines = {}
+  local show_coverage_in_sign_column = config.show_coverage_in_sign_column and true or false
 
   -- Create a map of line coverage for fast lookup
   local line_map = {}
@@ -292,18 +362,11 @@ function M.render_file(buf, file_entry)
     end
 
     -- Build virtual text (only for non-sign display modes)
-    local virt_text = {}
     local hit_count_display = config.hit_count and config.hit_count.display or "eol"
-    if hit_count_display ~= "sign" and hit_count_display ~= "" and hit_count then
-      table.insert(virt_text, { " " .. hit_count, hl_group })
-    end
+    local virt_text, virt_pos = build_virt_text(hit_count, hit_count_display, show_coverage_in_sign_column, hl_group)
 
-    if config.show_percentage and hit_count and hit_count > 0 then
-      table.insert(virt_text, { " (hit)", hl_group })
-    end
-
-    -- Place extmark on line with virtual text, line highlighting, and sign text
-    local should_render = #virt_text > 0 or config.enable_line_hl or (hit_count_display == "sign" and hit_count)
+    -- Place extmark on line with virtual text, line highlighting, and optional sign text
+    local should_render = show_coverage_in_sign_column or #virt_text > 0 or config.enable_line_hl or (hit_count_display == "sign" and hit_count)
 
     if should_render then
       local extmark_opts = {
@@ -312,39 +375,31 @@ function M.render_file(buf, file_entry)
         strict = false,
       }
 
+      if show_coverage_in_sign_column then
+        -- Use a left-half block glyph and apply a foreground-only sign
+        -- highlight so the colored portion appears on the left side of
+        -- the sign column cell while the rest remains the editor background.
+        extmark_opts.sign_text = "▌"
+        extmark_opts.sign_hl_group = get_sign_hl_for_group(hl_group)
+      end
+
       -- Add virtual text if present
       if #virt_text > 0 then
         extmark_opts.virt_text = virt_text
-        -- Only set virt_text_pos if it's a valid position (not "sign" or empty)
-        if hit_count_display == "eol" or hit_count_display == "inline" or hit_count_display == "overlay" or hit_count_display == "right_align" then
-          extmark_opts.virt_text_pos = hit_count_display
-        else
-          -- Default to eol for branch info when not in a valid display mode
-          extmark_opts.virt_text_pos = "eol"
-        end
+        extmark_opts.virt_text_pos = virt_pos or "eol"
       end
 
       -- Add line highlighting if enabled
-      if config.enable_line_hl then
+      if config.enable_line_hl and not show_coverage_in_sign_column then
         extmark_opts.line_hl_group = hl_group
       end
 
       -- Add sign text with hit count in sign column (left gutter)
       if hit_count_display == "sign" and hit_count then
-        local sign_text
-        if type(config.hit_count.sign_text_format) == "function" then
-          sign_text = config.hit_count.sign_text_format(hit_count)
-        elseif type(config.hit_count.sign_text_format) == "string" then
-          sign_text = string.format(config.hit_count.sign_text_format, hit_count)
-        else
-          -- Fallback: show exact hit count
-          sign_text = tostring(hit_count)
-        end
-        sign_text = format_sign_text(sign_text)
-        -- Only set sign_text if it's a valid non-empty string (Neovim requirement)
-        if sign_text and type(sign_text) == "string" and sign_text ~= "" then
+        local sign_text, sign_hl = get_hitcount_sign(buf, line_num, hit_count, hl_group, show_coverage_in_sign_column)
+        if sign_text and sign_text ~= "" then
           extmark_opts.sign_text = sign_text
-          extmark_opts.sign_hl_group = hl_group
+          extmark_opts.sign_hl_group = sign_hl
         end
       end
 

--- a/test/run_all.lua
+++ b/test/run_all.lua
@@ -137,6 +137,10 @@ end)
 
 -- 6. Renderer Display Modes
 print("\n[Renderer Display Modes]")
+test("Sign-column coverage defaults to disabled", function()
+  local config = require('crazy-coverage.config')
+  assert(config.get_config().show_coverage_in_sign_column == false)
+end)
 test("Sign-column coverage mode disables line highlights", function()
   local config = require('crazy-coverage.config')
   local renderer = require('crazy-coverage.renderer')
@@ -184,6 +188,80 @@ test("Sign-column coverage mode disables line highlights", function()
 
   config.set_config(previous_config)
   vim.api.nvim_buf_delete(buf, { force = true })
+
+  assert(ok, err)
+end)
+
+test("Hit-count sign uses sign highlight group in sign column", function()
+  local config = require('crazy-coverage.config')
+  local renderer = require('crazy-coverage.renderer')
+
+  local previous_config = config.get_config()
+  config.set_config({
+    show_coverage_in_sign_column = false,
+    enable_line_hl = true,
+    hit_count = {
+      display = "sign",
+      show_by_default = true,
+      sign_text_format = function(hit_count)
+        return tostring(hit_count)
+      end,
+    },
+  })
+
+  local buf = vim.api.nvim_create_buf(true, true)
+  local file_path = cwd .. "/test/fixtures/sign-hit-count.lua"
+  vim.api.nvim_buf_set_name(buf, file_path)
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, {"first line"})
+
+  local ok, err = pcall(function()
+    renderer.render_file(buf, {
+      path = file_path,
+      lines = {
+        { line = 1, hits = 4 },
+      },
+    })
+
+    local marks = vim.api.nvim_buf_get_extmarks(buf, renderer.namespace, 0, -1, { details = true })
+    assert(#marks == 1)
+
+    local details = marks[1][4]
+    local expected_sign_hl = config.covered_sign_hl or (config.covered_hl .. "Sign")
+    assert(details.sign_text ~= nil)
+    assert(details.sign_hl_group == expected_sign_hl)
+    assert(details.sign_hl_group ~= config.covered_hl)
+  end)
+
+  config.set_config(previous_config)
+  vim.api.nvim_buf_delete(buf, { force = true })
+
+  assert(ok, err)
+end)
+
+test("Sign-column coverage default stays false across config merges", function()
+  local config = require('crazy-coverage.config')
+
+  local previous_config = config.get_config()
+  local ok, err = pcall(function()
+    config.set_config({
+      show_coverage_in_sign_column = true,
+    })
+    assert(config.get_config().show_coverage_in_sign_column == true)
+
+    config.set_config({
+      hit_count = {
+        display = "eol",
+        show_by_default = true,
+        sign_text_format = function(hit_count)
+          return tostring(hit_count)
+        end,
+      },
+    })
+
+    assert(config.get_config().show_coverage_in_sign_column == false)
+  end)
+
+  config.set_config(previous_config)
 
   assert(ok, err)
 end)

--- a/test/run_all.lua
+++ b/test/run_all.lua
@@ -135,6 +135,59 @@ test("all results are at most 2 display cells", function()
   end
 end)
 
+-- 6. Renderer Display Modes
+print("\n[Renderer Display Modes]")
+test("Sign-column coverage mode disables line highlights", function()
+  local config = require('crazy-coverage.config')
+  local renderer = require('crazy-coverage.renderer')
+
+  local previous_config = config.get_config()
+  config.set_config({
+    show_coverage_in_sign_column = true,
+    enable_line_hl = true,
+    hit_count = {
+      display = "eol",
+      show_by_default = true,
+      sign_text_format = function(hit_count)
+        return tostring(hit_count)
+      end,
+    },
+  })
+
+  local buf = vim.api.nvim_create_buf(true, true)
+  local file_path = cwd .. "/test/fixtures/sign-column-mode.lua"
+  vim.api.nvim_buf_set_name(buf, file_path)
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, {"first line", "second line"})
+
+  local ok, err = pcall(function()
+    renderer.render_file(buf, {
+      path = file_path,
+      lines = {
+        { line = 1, hits = 4 },
+        { line = 2, hits = 0 },
+      },
+    })
+
+    local marks = vim.api.nvim_buf_get_extmarks(buf, renderer.namespace, 0, -1, { details = true })
+    assert(#marks == 2)
+
+    local first = marks[1][4]
+    assert(first.sign_text ~= nil)
+    assert(first.sign_hl_group ~= nil)
+    assert(first.line_hl_group == nil)
+    assert(first.virt_text ~= nil)
+
+    local second = marks[2][4]
+    assert(second.sign_text ~= nil)
+    assert(second.line_hl_group == nil)
+  end)
+
+  config.set_config(previous_config)
+  vim.api.nvim_buf_delete(buf, { force = true })
+
+  assert(ok, err)
+end)
+
 -- 6. Actual File Parsing (if fixtures exist)
 print("\n[File Parsing]")
 test("Parse LCOV fixture", function()


### PR DESCRIPTION
This pull request introduces a new feature to display coverage status in the Neovim sign column, along with improved configuration and documentation. The main theme is to provide users with more flexible and modern ways to visualize code coverage, separating coverage status from hit count display. It also adds a new command to toggle this feature and updates documentation to reflect the changes.

**New Coverage Status Sign Column Feature:**

- Added a new configuration option `show_coverage_in_sign_column` that, when enabled, displays coverage status markers in the sign column instead of using in-buffer line highlights. Hit count display remains configurable separately. (F3fadbfaL41R41, [[1]](diffhunk://#diff-c2f1f64eeb5238c809d70b333d9987646e84982e0b133ffa4e0ca1ff86c78448R78-R88) [[2]](diffhunk://#diff-9b84b9aa217ee35305fa8d765a8116e58b2fc20a6c51c474d44d790a1478b840L3-R101) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-R9) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R134)
- Implemented the rendering logic for coverage status signs, including new highlight groups for sign display and helpers to map coverage highlight groups to sign-specific groups. [[1]](diffhunk://#diff-842646519f4aa17cc8d2c233581e61c257410e18ba536001492a9fd31981647fR116-R183) [[2]](diffhunk://#diff-842646519f4aa17cc8d2c233581e61c257410e18ba536001492a9fd31981647fR218) [[3]](diffhunk://#diff-57f604539bb9c4695b960b828f3c39847f549bf3703c386c2124e46dcdee930fR477-R509)

**Commands and API:**

- Introduced the `:CoverageToggleSignColumn` command and supporting API to toggle the coverage sign column feature on and off, with immediate re-rendering. [[1]](diffhunk://#diff-431081d42cd04e2e3389c4a9b10094c6f66caeb3f0d43db0c72751ed78623f9bR1132-R1146) [[2]](diffhunk://#diff-431081d42cd04e2e3389c4a9b10094c6f66caeb3f0d43db0c72751ed78623f9bR1193-R1196) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R179)

**Documentation Updates:**

- Updated `README.md` and `doc/configuration.md` to document the new feature, configuration options, and commands. [[1]](diffhunk://#diff-c2f1f64eeb5238c809d70b333d9987646e84982e0b133ffa4e0ca1ff86c78448R78-R88) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-R9) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R134) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R179)
- Rewrote `doc/sign-display-feature.md` to clarify the difference between legacy hit count sign display and the new coverage status sign column, with configuration examples and usage scenarios. [[1]](diffhunk://#diff-9b84b9aa217ee35305fa8d765a8116e58b2fc20a6c51c474d44d790a1478b840L3-R101) [[2]](diffhunk://#diff-9b84b9aa217ee35305fa8d765a8116e58b2fc20a6c51c474d44d790a1478b840R110) [[3]](diffhunk://#diff-9b84b9aa217ee35305fa8d765a8116e58b2fc20a6c51c474d44d790a1478b840R158-R168)

**Configuration Enhancements:**

- Added new highlight groups for sign display, which automatically adapt to the user's colorscheme, and ensured they are not user-configurable to avoid confusion.
- Updated default configuration and setup logic to support the new feature. [[1]](diffhunk://#diff-57f604539bb9c4695b960b828f3c39847f549bf3703c386c2124e46dcdee930fR44-R46) [[2]](diffhunk://#diff-57f604539bb9c4695b960b828f3c39847f549bf3703c386c2124e46dcdee930fR566)

These changes make coverage visualization more flexible and user-friendly, especially for users who prefer sign column indicators over in-buffer highlighting.

## Summary by Sourcery

Add a configurable mode to display coverage status in the Neovim sign column, decoupling it from hit count display and wiring it into the existing rendering and toggle flows.

New Features:
- Introduce the `show_coverage_in_sign_column` option to render coverage status markers in the sign column instead of line background highlights.
- Add the `:CoverageToggleSignColumn` command and corresponding API to toggle sign-column coverage markers at runtime.

Enhancements:
- Extend renderer logic to support sign-column coverage markers alongside existing hit count display modes while avoiding conflicting line highlights.
- Generate dedicated foreground-only highlight groups for sign glyphs that automatically adapt to the user’s colorscheme.
- Adjust default configuration to better support sign-based coverage visualization.

Documentation:
- Update README and configuration reference to document the new sign-column coverage option and its interaction with hit count display.
- Rewrite the sign display feature guide to clearly distinguish legacy hit-count signs from the new coverage-status sign column, with updated examples and guidance.

Tests:
- Add renderer tests covering the sign-column coverage mode to ensure line highlights are disabled and signs/virtual text are applied as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New option to show coverage status in the sign column.
  * New toggle command (:CoverageToggleSignColumn) to enable/disable sign-column coverage display.

* **Documentation**
  * Docs updated to describe the flexible display model (virtual text vs sign column) and revised configuration examples and commands.

* **Tests**
  * Added renderer test covering sign-column display behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mr-u0b0dy/crazy-coverage.nvim/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->